### PR TITLE
Override deleteBackward since some 3rd party keyboards don't call keyboardInputShouldDelete

### DIFF
--- a/VENTokenField/VENBackspaceTextField.m
+++ b/VENTokenField/VENBackspaceTextField.m
@@ -24,15 +24,13 @@
 
 @implementation VENBackspaceTextField
 
-- (BOOL)keyboardInputShouldDelete:(UITextField *)textField
-{
+- (void)deleteBackward {
     if (self.text.length == 0) {
         if ([self.backspaceDelegate respondsToSelector:@selector(textFieldDidEnterBackspace:)]) {
             [self.backspaceDelegate textFieldDidEnterBackspace:self];
         }
     }
-
-    return YES;
+    [super deleteBackward];
 }
 
 @end

--- a/VENTokenField/VENBackspaceTextField.m
+++ b/VENTokenField/VENBackspaceTextField.m
@@ -24,6 +24,9 @@
 
 @implementation VENBackspaceTextField
 
+/**
+ Implementing backspace logic in deleteBackward since third party keyboards don't seem to call keyboardInputShouldDelete
+*/
 - (void)deleteBackward {
     if (self.text.length == 0) {
         if ([self.backspaceDelegate respondsToSelector:@selector(textFieldDidEnterBackspace:)]) {


### PR DESCRIPTION
Tested with Flow, SwiftKey, Google and standard keyboard.