### PR TITLE
Split delimiter out of the text

### DIFF
--- a/VENTokenField/VENBackspaceTextField.h
+++ b/VENTokenField/VENBackspaceTextField.h
@@ -33,6 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface VENBackspaceTextField : UITextField
 
+@property (nonatomic) BOOL onlyBackspaceAllowed;
 @property (weak, nonatomic) id<VENBackspaceTextFieldDelegate> backspaceDelegate;
 
 @end

--- a/VENTokenField/VENBackspaceTextField.m
+++ b/VENTokenField/VENBackspaceTextField.m
@@ -28,7 +28,7 @@
  Implementing backspace logic in deleteBackward since third party keyboards don't seem to call keyboardInputShouldDelete
 */
 - (void)deleteBackward {
-    if (self.text.length == 0) {
+    if (self.text.length == 0 || self.onlyBackspaceAllowed) {
         if ([self.backspaceDelegate respondsToSelector:@selector(textFieldDidEnterBackspace:)]) {
             [self.backspaceDelegate textFieldDidEnterBackspace:self];
         }

--- a/VENTokenField/VENToken.h
+++ b/VENTokenField/VENToken.h
@@ -28,10 +28,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (assign, nonatomic) BOOL highlighted;
 @property (copy, nonatomic, nullable) void (^didTapTokenBlock) (void);
-@property (strong, nonatomic) UIColor *colorScheme;
-@property (strong, nonatomic) UIFont *font;
 
-- (void)setTitleText:(NSAttributedString *)text;
+- (void)setTitleText:(NSString *)text showSeparator:(BOOL)seperator;
 
 @end
 

--- a/VENTokenField/VENToken.m
+++ b/VENTokenField/VENToken.m
@@ -68,13 +68,6 @@
     self.backgroundView.backgroundColor = backgroundColor;
 }
 
-- (void)setColorScheme:(UIColor *)colorScheme
-{
-    _colorScheme = colorScheme;
-    self.titleLabel.textColor = self.colorScheme;
-    [self setHighlighted:_highlighted];
-}
-
 - (void)setFont:(UIFont *)font {
     _font = font;
     [self setTitleText:self.titleLabel.text];

--- a/VENTokenField/VENTokenField.h
+++ b/VENTokenField/VENTokenField.h
@@ -81,19 +81,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (strong, nonatomic) NSString *toLabelText;
 @property (strong, nonatomic) UIFont *inputTextFieldFont;
 @property (strong, nonatomic) UIColor *inputTextFieldTextColor;
-@property (strong, nonatomic) UIFont *tokenFont;
-@property (strong, nonatomic) NSDictionary *separatorAttributes;
 
 @property (strong, nonatomic) UILabel *toLabel;
-
 @property (strong, nonatomic) UIFont *collapsedFont;
-
-@property (strong, nonatomic, nullable) NSArray *delimiters;
-@property (strong, nonatomic, nullable) NSString *tokenSeparator;
 @property (copy, nonatomic, nullable) NSString *placeholderText;
 @property (copy, nonatomic, nullable) NSString *inputTextFieldAccessibilityLabel;
-
-- (void)setColorScheme:(UIColor *)color;
 
 @end
 


### PR DESCRIPTION
Let VENToken deal with showing and hiding the delimiter.
VENTokenField only sets text and sends a flag for delimiter
on and off.

Also fixes bugs with the invisible backspace text field and deselecting
tokens when the field becomes defocused.