### PR TITLE
Add shouldChangeCharactersInRange to delegate methods

### DIFF
--- a/VENTokenField/VENTokenField.h
+++ b/VENTokenField/VENTokenField.h
@@ -35,6 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)tokenField:(VENTokenField *)tokenField didChangeContentHeight:(CGFloat)height;
 - (void)tokenField:(VENTokenField *)tokenField didTapTokenAtIndex:(NSUInteger)index;
 - (void)tokenFieldDidTapCollapsed:(VENTokenField *)tokenField;
+- (BOOL)tokenField:(VENTokenField *)tokenField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string;
 @end
 
 @protocol VENTokenFieldDataSource <NSObject>

--- a/VENTokenField/VENTokenField.m
+++ b/VENTokenField/VENTokenField.m
@@ -675,6 +675,10 @@ static const CGFloat VENTokenFieldDefaultMaxHeight          = 150.0;
         [self unhighlightAllTokens];
     }
 
+    if ([self.delegate respondsToSelector:@selector(tokenField:shouldChangeCharactersInRange:replacementString:)]) {
+        return [self.delegate tokenField:self shouldChangeCharactersInRange:range replacementString:string];
+    }
+
     return YES;
 }
 


### PR DESCRIPTION
Let the delegate handle `shouldChangeCharactersInRange` so that it can intercept when it needs to - eg when user pastes some text like `mailto:sanket@superhuman.com` and we want to strip out `mailto:`.