### PR TITLE
Handle removing highlighted token before adding characters

### DIFF
--- a/VENTokenField/VENTokenField.m
+++ b/VENTokenField/VENTokenField.m
@@ -675,11 +675,24 @@ static const CGFloat VENTokenFieldDefaultMaxHeight          = 150.0;
         [self unhighlightAllTokens];
     }
 
-    if ([self.delegate respondsToSelector:@selector(tokenField:shouldChangeCharactersInRange:replacementString:)]) {
-        return [self.delegate tokenField:self shouldChangeCharactersInRange:range replacementString:string];
+    BOOL hasHighlightedToken = NO;
+    for (UIView<VENTokenObject> *token in self.tokens) {
+        if (token.highlighted) {
+            hasHighlightedToken = YES;
+            break;
+        }
     }
 
-    return YES;
+    if (hasHighlightedToken) {
+        [self textFieldDidEnterBackspace:(VENBackspaceTextField*) textField];
+        return YES;
+    } else {
+        if ([self.delegate respondsToSelector:@selector(tokenField:shouldChangeCharactersInRange:replacementString:)]) {
+            return [self.delegate tokenField:self shouldChangeCharactersInRange:range replacementString:string];
+        }
+
+        return YES;
+    }
 }
 
 


### PR DESCRIPTION
If any token in the field is highlighted (selected), user intends to remove it and then type the new character. I have tested with highlighting the last token as well tokens in between and this works fine. Also tested with multiple recipient fields.

Fixes https://github.com/superhuman/superhuman-ios/issues/2650